### PR TITLE
Handle missing stacktrace & JUnit5, AssertJ, Hamcrest exceptions

### DIFF
--- a/src/main/webapp/diffview.css
+++ b/src/main/webapp/diffview.css
@@ -1,18 +1,3 @@
-body {
-    font-family: "Arial";
-    font-size: 10px;
-    overflow-y: scroll;
-}
-body.default {
-    background: url("images/body.gif") repeat-x #a8b8c8;
-    color: #000;
-}
-body.default button {
-    background: #dfd;
-    border-color: #030;
-    box-shadow: 0px 0.1em 0.2em rgba(0, 32, 0, 0.75);
-    color: #030;
-}
 .default a {
     color: #f00;
 }
@@ -2038,7 +2023,7 @@ table.diff tbody td {
     letter-spacing: 0.1em;
     padding: 0.5em 0.5em 0px;
     vertical-align: top;
-    white-space: pre;
+    white-space: pre-wrap;
 }
 table.diff tbody td em {
     font-style: normal;

--- a/src/main/webapp/expected.js
+++ b/src/main/webapp/expected.js
@@ -65,7 +65,10 @@ function prettyPrint(input) {
 
 function match (stacktrace) {
     var patterns = [
-    	/expected:[\s]*<([\s\S]*)>[\s]+but[\s]+was:[\s]*<([\s\S]*)>/];
+    	/expected:[\s]*<([\s\S]*)>[\s]+but[\s]+was:[\s]*<([\s\S]*)>/, // JUnit assertEquals
+    	/Expected:[\s]*"([\s\S]*)"[\s]+but:[\s]was[\s]+"([\s\S]*)"/, // Hamcrest
+    	/Expecting:[\s]*<"([\s\S]*)">[\s]+to be equal to:[\s]+<"([\s\S]*)">[\s]+but was not/ // AssertJ
+    	];
     for (i=0; i<patterns.length; i++) {
       var matched = stacktrace.match(patterns[i]);
       if (matched != null)

--- a/src/main/webapp/expected.js
+++ b/src/main/webapp/expected.js
@@ -65,38 +65,38 @@ function prettyPrint(input) {
 
 function match (stacktrace) {
     var patterns = [
-        /^[a-zA-Z]+[.][a-zA-Z]+[.][a-zA-Z]+:[\s\S]+expected:&lt;([\s\S]*)&gt;[\s\S]+but[\s\S]+was:&lt;([\s\S]*)&gt;/,
-        /^[a-zA-Z]+[.][a-zA-Z]+[.][a-zA-Z]+:[\s\S]+expected[\s\S]+same:&lt;([\s\S]*)&gt;[\s\S]+was[\s\S]+not:&lt;([\s\S]*)&gt;/,
-        /^[a-zA-Z]+[.][a-zA-Z]+[.][a-zA-Z]+:[\s\S]+Expected:[\s\S]+is[\s\S]+&lt;([\s\S]*)&gt;[\s\S]+got:[\s\S]*&lt;([\s\S]*)&gt;/,
-        /^[a-zA-Z]+[.][a-zA-Z]+[.][a-zA-Z]+:[\s\S]+Expected:[\s\S]+&lt;([\s\S]*)&gt;[\s\S]+got:[\s\S]*&lt;([\s\S]*)&gt;/,
-        /^[a-zA-Z]+[.][a-zA-Z]+[.][a-zA-Z]+:[\s\S]+expected[\s\S]+same[\s\S]+instance[\s\S]+but[\s\S]+found:&lt;([\s\S]*)&gt;[\s\S]+and:[\s\S]*&lt;([\s\S]*)&gt;/
-        ];
-        for (i=0; i<patterns.length; i++)
-  {
+    	/expected:[\s]*<([\s\S]*)>[\s]+but[\s]+was:[\s]*<([\s\S]*)>/];
+    for (i=0; i<patterns.length; i++) {
       var matched = stacktrace.match(patterns[i]);
       if (matched != null)
           return matched;
-  }
+    }
   return null;
 }
 
 function diffUsingJS () {
-    var stacktraceHeader = dojo.filter(dojo.query("h3"), function(header){ return header.innerHTML == 'Stacktrace'; })[0];
- 
-    var stacktrace = stacktraceHeader.nextSibling.innerHTML;
-    if(stacktrace != undefined) {
-        var matched = match(stacktrace);
-    	if (matched != null) {
-    	var expected = matched[1];
-	var actual = matched[2];
-    	var diffoutputdiv = $("diffoutput");
-	while (diffoutputdiv.firstChild) diffoutputdiv.removeChild(diffoutputdiv.firstChild);
+    var preNodes = dojo.query("#main-panel > pre");
 
-        var exp = prettyPrint(expected);
-        var act = prettyPrint(actual);
-	var output = prettydiff(apiParams(exp, act));
-	dojo.place(output[0],diffoutputdiv);
-	}
+    if (preNodes.length > 0) {
+        var matched;
+    	if (preNodes[1]) { // error message + stacktrace 
+    		matched = match(preNodes[1].textContent);
+    	}
+    	if (!matched) { // only error message
+    		matched = match(preNodes[0].textContent);
+    	}
+    	if (matched != null) {
+    		var expected = matched[1];
+    		var actual = matched[2];
+    		var diffoutputdiv = $("diffoutput");
+    		while (diffoutputdiv.firstChild)
+    			diffoutputdiv.removeChild(diffoutputdiv.firstChild);
+
+    		var exp = prettyPrint(expected).replace(/\r?\n/g, "<br/>\n");
+    		var act = prettyPrint(actual).replace(/\r?\n/g, "<br/>\n");
+    		var output = prettydiff(apiParams(exp, act));
+    		dojo.place(output[0], diffoutputdiv);
+    	}
     }
 }
 dojo.addOnLoad(function() {


### PR DESCRIPTION
Made working for Jenkins ver. 2.204.2 with:
- no stacktrace available (Ant 1.10.7 with junitlaucher task)
- verified with String comparison exceptions thrown by Junit4 (4.12), JUnit 5 (5.5.1), Hamcrest (2.1) and AssertJ (3.13.2) 
- removed CSS styles changing the whole page